### PR TITLE
Add translation tool using Google Translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ MCP (Model Context Protocol) allows AI assistants like Puch to connect to extern
 - **Fetch job postings from URLs** - Give a job posting link and get the full details
 - **Search for jobs** - Use natural language to find relevant job opportunities
 
+### 🌐 Translation Tool
+- **Translate text** - Convert text between languages with automatic source detection
+
 ### 🖼️ Image Processing Tool
 - **Convert images to black & white** - Upload any image and get a monochrome version
 


### PR DESCRIPTION
## Summary
- add translate tool that calls Google Translate with auto language detection
- document new translation feature in README

## Testing
- `python -m py_compile mcp-bearer-token/mcp_starter.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689731bcc26c832eb3c1acfa0e123b8f