### PR TITLE
Add bill splitting and expense tracking tools

### DIFF
--- a/tests/test_expense_tracker.py
+++ b/tests/test_expense_tracker.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 import os
+from datetime import datetime, timedelta
 from pathlib import Path
 import sys
 
@@ -22,16 +23,17 @@ def test_storage_queries_and_export(tmp_path):
     try:
         storage = ExpenseStorage(db_path="test.db")
         now = datetime.now()
-        storage.add_expense(100, "food", now)
-        storage.add_expense(50, "food", now - timedelta(days=1))
-        storage.add_expense(20, "food", now - timedelta(days=31))
-        storage.add_expense(70, "travel", now)
+        phone = "+15550000000"
+        storage.add_expense(phone, 100, "food", now)
+        storage.add_expense(phone, 50, "food", now - timedelta(days=1))
+        storage.add_expense(phone, 20, "food", now - timedelta(days=31))
+        storage.add_expense(phone, 70, "travel", now)
 
-        weekly = storage.weekly_summary()
+        weekly = storage.weekly_summary(phone)
         assert weekly["food"] == 150
         assert weekly["travel"] == 70
 
-        monthly = storage.monthly_category_breakdown("food")
+        monthly = storage.monthly_category_breakdown(phone, "food")
         today = now.strftime("%Y-%m-%d")
         yesterday = (now - timedelta(days=1)).strftime("%Y-%m-%d")
         old_date = (now - timedelta(days=31)).strftime("%Y-%m-%d")
@@ -39,8 +41,8 @@ def test_storage_queries_and_export(tmp_path):
         assert monthly[yesterday] == 50
         assert old_date not in monthly
 
-        csv_file = storage.export_data("csv")
-        json_file = storage.export_data("json")
+        csv_file = storage.export_data("csv", phone)
+        json_file = storage.export_data("json", phone)
         assert Path(csv_file).exists()
         assert Path(json_file).exists()
     finally:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,36 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+def test_tool_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUTH_TOKEN", "token")
+    monkeypatch.setenv("MY_NUMBER", "+19999999999")
+    monkeypatch.setenv("EXPENSE_DB_PATH", str(tmp_path / "exp.db"))
+
+    root = Path(__file__).resolve().parents[1]
+    sys.path.append(str(root))
+    spec = importlib.util.spec_from_file_location(
+        "mcp_starter", root / "mcp-bearer-token" / "mcp_starter.py"
+    )
+    mcp = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mcp)
+
+    split = asyncio.run(mcp.split_bill.fn(100, 4, 10))
+    assert split == pytest.approx(27.5)
+
+    asyncio.run(mcp.add_expense.fn("+15550000000", 25, "food"))
+    asyncio.run(mcp.add_expense.fn("+15550000000", 10, "travel"))
+
+    summary = asyncio.run(mcp.weekly_summary.fn("+15550000000"))
+    assert summary["food"] == 25
+    assert summary["travel"] == 10
+
+    asyncio.run(mcp.add_expense.fn("+15556667777", 5, "food"))
+    other = asyncio.run(mcp.weekly_summary.fn("+15556667777"))
+    assert other["food"] == 5
+    assert "travel" not in other


### PR DESCRIPTION
## Summary
- Track expenses per user in SQLite with input validation
- Expose `split_bill`, `add_expense`, and `weekly_summary` MCP tools
- Test tool flows and persistence across users

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897548b88d4832ea8a9e90359cbd067