### PR TITLE
Add news headlines MCP tool with error handling and tests

### DIFF
--- a/news.py
+++ b/news.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import os
 import time
-from dataclasses import dataclass
 from typing import List, Tuple
+
 import httpx
 import xml.etree.ElementTree as ET
 
@@ -60,10 +60,13 @@ def get_headlines(category: str | None = None, region: str | None = None) -> str
             return summary
 
     url = _build_url(category, region)
-    with httpx.Client() as client:
-        resp = client.get(url, timeout=10, follow_redirects=True)
-        resp.raise_for_status()
-        xml_text = resp.text
+    try:
+        with httpx.Client() as client:
+            resp = client.get(url, timeout=10, follow_redirects=True)
+            resp.raise_for_status()
+            xml_text = resp.text
+    except httpx.HTTPError:
+        return "Error fetching news headlines. Please try again later."
 
     headlines = _parse_rss(xml_text)
     if not headlines:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "dotenv>=0.9.9",
     "fastmcp>=2.11.2",
     "google-api-python-client>=2.178.0",
+    "httpx>=0.28.1",
     "markdownify>=1.1.0",
     "pillow>=11.3.0",
     "python-dotenv>=1.1.1",

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import news  # noqa: E402
+
+
+def test_get_headlines_success():
+    news._cache.clear()
+    sample_xml = (
+        "<rss><channel>"
+        "<item><title>Headline1</title><link>http://link1</link></item>"
+        "<item><title>Headline2</title><link>http://link2</link></item>"
+        "</channel></rss>"
+    )
+
+    class MockResponse:
+        def __init__(self, text, status_code=200):
+            self.text = text
+            self.status_code = status_code
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError(
+                    "error",
+                    request=httpx.Request("GET", "http://test"),
+                    response=httpx.Response(self.status_code),
+                )
+
+    with patch("httpx.Client.get", return_value=MockResponse(sample_xml)):
+        result = news.get_headlines()
+
+    assert "- Headline1 (http://link1)" in result
+    assert "- Headline2 (http://link2)" in result
+
+
+def test_get_headlines_network_error():
+    news._cache.clear()
+    request = httpx.Request("GET", "https://news.google.com/rss")
+    with patch("httpx.Client.get", side_effect=httpx.RequestError("boom", request=request)):
+        result = news.get_headlines()
+
+    assert result == "Error fetching news headlines. Please try again later."


### PR DESCRIPTION
## Summary
- Add `news_headlines` MCP tool that fetches top headlines with optional category and region
- Handle RSS fetch errors gracefully with try/except
- Add unit tests for successful fetches and simulated network errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68975490b3c8832e9bbb8dc61dbbb7f5