### PR TITLE
Add calculator MCP server with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,31 @@ calc sin(pi / 2) + 2**3
 
 Each command returns a human-readable response and helpful error messages for
 invalid input.
+
+## Calculator MCP Server
+
+A lightweight MCP server exposes a `calculate` tool backed by the
+`scientific_calculator` helper.
+
+### Run the server
+
+```bash
+cd mcp-calculator
+python mcp_calculator.py
+```
+
+The server listens on port `8088`.
+
+### Connect from Puch
+
+Once the server is running locally you can connect:
+
+```text
+/mcp connect http://localhost:8088/mcp
+```
+
+You can then evaluate expressions, e.g.:
+
+```text
+/mcp run calculate {"expression": "sin(pi/2) + 2**3"}
+```

--- a/mcp-calculator/mcp_calculator.py
+++ b/mcp-calculator/mcp_calculator.py
@@ -1,0 +1,31 @@
+import asyncio
+from typing import Annotated
+
+from fastmcp import FastMCP
+from mcp import ErrorData, McpError
+from mcp.types import INVALID_PARAMS
+from pydantic import Field
+
+from utility_dispatcher import scientific_calculator
+
+mcp = FastMCP("Calculator MCP Server")
+
+
+@mcp.tool(description="Evaluate a mathematical expression")
+async def calculate(
+    expression: Annotated[str, Field(description="The expression to evaluate")]
+) -> float:
+    """Evaluate a math expression using the scientific calculator."""
+    try:
+        return scientific_calculator(expression)
+    except ValueError as exc:
+        raise McpError(ErrorData(code=INVALID_PARAMS, message=str(exc)))
+
+
+async def main() -> None:
+    print("\U0001F680 Starting Calculator MCP server on http://0.0.0.0:8088")
+    await mcp.run_async("streamable-http", host="0.0.0.0", port=8088)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_mcp_calculator.py
+++ b/tests/test_mcp_calculator.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import asyncio
+
+import pytest
+
+# Add path to the mcp-calculator module
+sys.path.append(str(Path(__file__).resolve().parents[1] / "mcp-calculator"))
+
+from mcp_calculator import calculate  # noqa: E402
+from mcp import McpError  # noqa: E402
+
+
+def test_calculate():
+    result = asyncio.run(calculate.fn("sin(pi / 2) + 2**3"))
+    assert result == pytest.approx(9.0)
+
+
+def test_calculate_invalid():
+    with pytest.raises(McpError):
+        asyncio.run(calculate.fn("2 +"))
+


### PR DESCRIPTION
## Summary
- add standalone calculator FastMCP server exposing a `calculate` tool
- document how to run and connect to the calculator server
- cover calculator tool with basic tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689754829bb0832eab991d47e48f2521