### PR TITLE
Ensure parent path is on sys.path for bearer token starter

### DIFF
--- a/mcp-bearer-token/mcp_starter.py
+++ b/mcp-bearer-token/mcp_starter.py
@@ -26,6 +26,10 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     def answer_question(_: str) -> str:
         return "Legal assistant unavailable."
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 from expense_tracker import ExpenseStorage
 from utility_dispatcher import split_bill as split_bill_func
 


### PR DESCRIPTION
## Summary
- append repository parent directory to `sys.path` in `mcp_starter` so `expense_tracker` can be imported

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689760cc3848832eb999701d1a57b07e