### PR TITLE
feat: add async news service

### DIFF
--- a/docs/user_functions.md
+++ b/docs/user_functions.md
@@ -42,7 +42,7 @@ Examples:
 Fetch top Google News headlines by category and region.
 Example:
 ```
-/mcp run get_headlines {"category": "WORLD", "region": "US"}
+/mcp run headlines {"category": "WORLD", "region": "US"}
 ```
 
 ## Utility Dispatcher

--- a/mcp-news/mcp_news.py
+++ b/mcp-news/mcp_news.py
@@ -1,0 +1,27 @@
+import asyncio
+from typing import Annotated
+
+from fastmcp import FastMCP
+from pydantic import Field
+
+from news_service import get_headlines
+
+mcp = FastMCP("News MCP Server")
+
+
+@mcp.tool(description="Fetch top Google News headlines")
+async def headlines(
+    category: Annotated[str | None, Field(description="Google News topic", example="WORLD")] = None,
+    region: Annotated[str | None, Field(description="Region code", example="US")] = None,
+    limit: Annotated[int, Field(gt=0, le=10, description="Number of headlines to return")] = 5,
+) -> str:
+    return await get_headlines(category=category, region=region, limit=limit)
+
+
+async def main() -> None:
+    print("\U0001F4F0 Starting News MCP server on http://0.0.0.0:8089")
+    await mcp.run_async("streamable-http", host="0.0.0.0", port=8089)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp-news/news_service.py
+++ b/mcp-news/news_service.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import os
 import time
-from dataclasses import dataclass
 from typing import List, Tuple
+
 import httpx
 import xml.etree.ElementTree as ET
 
-# Cache structure: { (category, region): (timestamp, summary_string) }
-_cache: dict[Tuple[str, str], Tuple[float, str]] = {}
+# Cache structure: { (category, region, limit): (timestamp, summary_string) }
+_cache: dict[Tuple[str, str, int], Tuple[float, str]] = {}
 
 # Cache duration in seconds, configurable via env var NEWS_CACHE_TTL (default 600 sec)
 CACHE_TTL = int(os.getenv("NEWS_CACHE_TTL", "600"))
@@ -32,7 +32,7 @@ def _build_url(category: str | None, region: str | None) -> str:
 def _parse_rss(xml_text: str, limit: int = 5) -> List[Tuple[str, str]]:
     """Parse RSS XML and return list of (title, link)."""
     root = ET.fromstring(xml_text)
-    items = []
+    items: List[Tuple[str, str]] = []
     for item in root.findall("./channel/item")[:limit]:
         title = item.findtext("title")
         link = item.findtext("link")
@@ -41,31 +41,26 @@ def _parse_rss(xml_text: str, limit: int = 5) -> List[Tuple[str, str]]:
     return items
 
 
-def get_headlines(category: str | None = None, region: str | None = None) -> str:
-    """Return a chatbot-friendly summary of top news headlines.
-
-    Args:
-        category: Optional Google News topic (e.g., 'WORLD', 'BUSINESS').
-        region: Optional region code (e.g., 'US', 'GB').
-
-    Returns:
-        A string with bullet-point headlines and URLs.
-    """
-    key = (category or "", region or "")
+async def get_headlines(
+    category: str | None = None,
+    region: str | None = None,
+    limit: int = 5,
+) -> str:
+    """Return a chatbot-friendly summary of top news headlines."""
+    key = (category or "", region or "", limit)
     now = time.time()
-    # Return cached result if valid
     if key in _cache:
         ts, summary = _cache[key]
         if now - ts < CACHE_TTL:
             return summary
 
     url = _build_url(category, region)
-    with httpx.Client() as client:
-        resp = client.get(url, timeout=10, follow_redirects=True)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, timeout=10, follow_redirects=True)
         resp.raise_for_status()
         xml_text = resp.text
 
-    headlines = _parse_rss(xml_text)
+    headlines = _parse_rss(xml_text, limit=limit)
     if not headlines:
         summary = "No headlines found."
     else:


### PR DESCRIPTION
## Summary
- move news service into dedicated `mcp-news` module
- expose `headlines` MCP tool with async Google News fetcher and caching
- document usage of new `headlines` tool

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689768d939e0832ea68a432098ed113b