### PR TITLE
feat: replace news tool with NewsAPI

### DIFF
--- a/docs/user_functions.md
+++ b/docs/user_functions.md
@@ -39,10 +39,10 @@ Examples:
 ```
 
 ## News Headlines
-Fetch top Google News headlines by category and region.
+Fetch top headlines using the NewsAPI service. You can filter by search term, country or category and the tool returns the raw JSON from the API.
 Example:
 ```
-/mcp run headlines {"category": "WORLD", "region": "US"}
+/mcp run headlines {"country": "us", "category": "technology", "limit": 3}
 ```
 
 ## Utility Dispatcher

--- a/mcp-bearer-token/mcp_starter.py
+++ b/mcp-bearer-token/mcp_starter.py
@@ -28,8 +28,6 @@ except Exception:  # pragma: no cover - optional dependency
         return "Legal assistant unavailable."
 import sys
 from pathlib import Path
-import xml.etree.ElementTree as ET
-import time
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from expense_tracker import ExpenseStorage
@@ -50,8 +48,6 @@ SPOTIFY_CLIENT_ID = os.environ.get("SPOTIFY_CLIENT_ID")
 SPOTIFY_CLIENT_SECRET = os.environ.get("SPOTIFY_CLIENT_SECRET")
 SPOTIFY_REFRESH_TOKEN = os.environ.get("SPOTIFY_REFRESH_TOKEN")
 
-# News cache configuration
-NEWS_CACHE_TTL = int(os.environ.get("NEWS_CACHE_TTL", "600"))
 
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
@@ -63,9 +59,6 @@ if os.path.exists(CALENDAR_TOKENS_FILE):
             _calendar_tokens.update(json.load(f))
     except Exception:
         pass
-
-# News cache structure: { (category, region, limit): (timestamp, summary_string) }
-_news_cache: dict[tuple[str, str, int], tuple[float, str]] = {}
 
 # Spotify access token
 _spotify_access_token: str | None = None
@@ -212,169 +205,29 @@ async def _spotify_request(method: str, url: str, **kwargs) -> httpx.Response:
     return resp
 
 # --- News Helper Functions ---
-def _build_news_url(category: str | None, region: str | None) -> str:
-    """Build the Google News RSS URL for given category and region."""
-    base = "https://news.google.com/rss"
-    params = []
-    if region:
-        region = region.upper()
-        params.append(f"hl={region}")
-        params.append(f"gl={region}")
-        params.append(f"ceid={region}:{region}")
-    if category:
-        params.append(f"topic={category.upper()}")
-    return f"{base}?{'&'.join(params)}" if params else base
-
-def _parse_news_rss(xml_text: str, limit: int = 5) -> list[tuple[str, str]]:
-    """Parse RSS XML and return list of (title, link)."""
-    try:
-        # Clean the XML text first
-        xml_text = xml_text.strip()
-        if not xml_text:
-            return []
-        
-        root = ET.fromstring(xml_text)
-        items: list[tuple[str, str]] = []
-        
-        # Try different possible paths for RSS structure
-        item_paths = [
-            "./channel/item",
-            ".//item",
-            "./item"
-        ]
-        
-        items_found = []
-        for path in item_paths:
-            items_found = root.findall(path)
-            if items_found:
-                break
-        
-        for item in items_found[:limit]:
-            title_elem = item.find("title")
-            link_elem = item.find("link")
-            
-            title = title_elem.text if title_elem is not None and title_elem.text else None
-            link = link_elem.text if link_elem is not None and link_elem.text else None
-            
-            if title and link:
-                # Clean up the title and link
-                title = title.strip()
-                link = link.strip()
-                if title and link:
-                    items.append((title, link))
-        
-        return items
-    except ET.ParseError:
-        # If XML parsing fails, try to extract basic information using regex
-        import re
-        items = []
-        
-        try:
-            # Simple regex to find title and link patterns
-            title_pattern = r'<title[^>]*>(.*?)</title>'
-            link_pattern = r'<link[^>]*>(.*?)</link>'
-            
-            titles = re.findall(title_pattern, xml_text, re.IGNORECASE | re.DOTALL)
-            links = re.findall(link_pattern, xml_text, re.IGNORECASE | re.DOTALL)
-            
-            # Skip the first title (usually the feed title) and match titles with links
-            for i, (title, link) in enumerate(zip(titles[1:], links[1:]), 1):
-                if i > limit:
-                    break
-                title = title.strip()
-                link = link.strip()
-                if title and link and not title.startswith("Google News"):
-                    items.append((title, link))
-        except Exception:
-            pass
-        
-        return items
-    except Exception:
-        return []
-
 async def get_headlines(
+    query: str | None = None,
+    country: str | None = "us",
     category: str | None = None,
-    region: str | None = None,
     limit: int = 5,
-) -> str:
-    """Return a chatbot-friendly summary of top news headlines."""
-    try:
-        # Validate inputs
-        if limit < 1 or limit > 10:
-            limit = 5
-        
-        key = (category or "", region or "", limit)
-        now = time.time()
-        if key in _news_cache:
-            ts, summary = _news_cache[key]
-            if now - ts < NEWS_CACHE_TTL:
-                return summary
+) -> dict:
+    """Fetch top headlines from NewsAPI and return JSON data."""
+    api_key = os.getenv("NEWS_API")
+    if not api_key:
+        raise McpError(ErrorData(code=INTERNAL_ERROR, message="NEWS_API environment variable not set"))
 
-        url = _build_news_url(category, region)
-        
-        # Try the main URL first
-        headlines = []
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(url, timeout=15, follow_redirects=True)
-                resp.raise_for_status()
-                xml_text = resp.text
+    params: dict[str, str | int] = {"apiKey": api_key, "pageSize": limit}
+    if query:
+        params["q"] = query
+    if country:
+        params["country"] = country
+    if category:
+        params["category"] = category
 
-            headlines = _parse_news_rss(xml_text, limit=limit)
-        except Exception as e:
-            # If main URL fails, try fallback
-            pass
-        
-        # If no headlines found, try fallback approach
-        if not headlines:
-            fallback_url = "https://news.google.com/rss"
-            try:
-                async with httpx.AsyncClient() as client:
-                    resp = await client.get(fallback_url, timeout=15, follow_redirects=True)
-                    resp.raise_for_status()
-                    xml_text = resp.text
-                
-                headlines = _parse_news_rss(xml_text, limit=limit)
-            except Exception:
-                pass
-        
-        # If still no headlines, try a different approach
-        if not headlines:
-            try:
-                # Try a simple news API as last resort
-                async with httpx.AsyncClient() as client:
-                    resp = await client.get("https://news.google.com/rss/search?q=latest&hl=en-US&gl=US&ceid=US:en", timeout=15)
-                    resp.raise_for_status()
-                    xml_text = resp.text
-                
-                headlines = _parse_news_rss(xml_text, limit=limit)
-            except Exception:
-                pass
-        
-        if not headlines:
-            summary = "No headlines found. Please try again later."
-        else:
-            lines = []
-            for i, (title, link) in enumerate(headlines, 1):
-                # Clean up the title and link
-                title = title.replace('\n', ' ').replace('\r', ' ').strip()
-                link = link.strip()
-                lines.append(f"{i}. {title}")
-                if link and not link.startswith('#'):
-                    lines.append(f"   Link: {link}")
-                lines.append("")
-            
-            summary = "\n".join(lines).strip()
-
-        _news_cache[key] = (now, summary)
-        return summary
-        
-    except httpx.HTTPStatusError as e:
-        return f"Error fetching news: HTTP {e.response.status_code}. Please try again later."
-    except httpx.RequestError as e:
-        return f"Error connecting to news service: {str(e)}. Please try again later."
-    except Exception as e:
-        return f"Error processing news: {str(e)}. Please try again later."
+    async with httpx.AsyncClient() as client:
+        resp = await client.get("https://newsapi.org/v2/top-headlines", params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
 
 # --- MCP Server Setup ---
 mcp = FastMCP(
@@ -783,90 +636,19 @@ async def spotify_current() -> str:
 # --- News Tools ---
 
 NEWS_HEADLINES_DESCRIPTION = RichToolDescription(
-    description="Fetch top Google News headlines",
-    use_when="Use this tool when the user wants to get the latest news headlines.",
-    side_effects="Returns a list of current news headlines with links.",
+    description="Fetch top headlines from NewsAPI",
+    use_when="Use this tool when the user wants the latest news headlines.",
+    side_effects="Returns JSON data with current news articles.",
 )
 
 @mcp.tool(description=NEWS_HEADLINES_DESCRIPTION.model_dump_json())
 async def news_headlines(
-    category: Annotated[str | None, Field(description="Google News topic", example="WORLD")] = None,
-    region: Annotated[str | None, Field(description="Region code", example="US")] = None,
-    limit: Annotated[int, Field(gt=0, le=10, description="Number of headlines to return")] = 5,
-) -> str:
-    """Fetch top Google News headlines."""
-    try:
-        result = await get_headlines(category=category, region=region, limit=limit)
-        
-        # Add context about the request
-        context = []
-        if category:
-            context.append(f"Category: {category}")
-        if region:
-            context.append(f"Region: {region}")
-        
-        if context:
-            header = f"📰 **Latest News** ({', '.join(context)})\n\n"
-        else:
-            header = "📰 **Latest News**\n\n"
-        
-        return header + result
-        
-    except Exception as e:
-        return f"❌ **News Error**: Unable to fetch headlines. {str(e)}\n\nPlease try again later or check your internet connection."
-
-
-NEWS_TEST_DESCRIPTION = RichToolDescription(
-    description="Test news functionality and get debug information",
-    use_when="Use this tool to test if news functionality is working properly.",
-    side_effects="Returns debug information about news service status.",
-)
-
-@mcp.tool(description=NEWS_TEST_DESCRIPTION.model_dump_json())
-async def news_test() -> str:
-    """Test news functionality and provide debug information."""
-    try:
-        # Test basic connectivity
-        test_url = "https://news.google.com/rss"
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(test_url, timeout=10)
-            status = resp.status_code
-            content_length = len(resp.text)
-        
-        # Test parsing
-        parse_success = False
-        parse_error_msg = "Unknown error"
-        headlines = []
-        
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(test_url, timeout=10)
-                headlines = _parse_news_rss(resp.text, limit=3)
-                parse_success = len(headlines) > 0
-        except Exception as parse_error:
-            parse_success = False
-            parse_error_msg = str(parse_error)
-        
-        # Build debug report
-        report = "🔍 **News Service Debug Report**\n\n"
-        report += f"✅ **Connectivity**: HTTP {status}\n"
-        report += f"📊 **Content Size**: {content_length} characters\n"
-        
-        if parse_success:
-            report += f"✅ **Parsing**: Successful ({len(headlines)} headlines found)\n"
-            report += "\n**Sample Headlines:**\n"
-            for i, (title, link) in enumerate(headlines[:2], 1):
-                report += f"{i}. {title[:50]}...\n"
-        else:
-            report += f"❌ **Parsing**: Failed - {parse_error_msg}\n"
-        
-        report += f"\n⏰ **Cache Status**: {len(_news_cache)} cached entries\n"
-        report += f"🔧 **Cache TTL**: {NEWS_CACHE_TTL} seconds\n"
-        
-        return report
-        
-    except Exception as e:
-        return f"❌ **Debug Error**: {str(e)}"
+    query: Annotated[str | None, Field(description="Search term", example="AI")] = None,
+    country: Annotated[str | None, Field(description="Two-letter country code", example="us")] = "us",
+    category: Annotated[str | None, Field(description="News category", example="technology")] = None,
+    limit: Annotated[int, Field(gt=0, le=100, description="Number of articles to return")] = 5,
+) -> dict:
+    return await get_headlines(query=query, country=country, category=category, limit=limit)
 
 
 # --- Calculator Tools ---

--- a/mcp-news/mcp_news.py
+++ b/mcp-news/mcp_news.py
@@ -9,13 +9,14 @@ from news_service import get_headlines
 mcp = FastMCP("News MCP Server")
 
 
-@mcp.tool(description="Fetch top Google News headlines")
+@mcp.tool(description="Fetch news headlines from NewsAPI")
 async def headlines(
-    category: Annotated[str | None, Field(description="Google News topic", example="WORLD")] = None,
-    region: Annotated[str | None, Field(description="Region code", example="US")] = None,
-    limit: Annotated[int, Field(gt=0, le=10, description="Number of headlines to return")] = 5,
-) -> str:
-    return await get_headlines(category=category, region=region, limit=limit)
+    query: Annotated[str | None, Field(description="Search term", example="AI")] = None,
+    country: Annotated[str | None, Field(description="Two-letter country code", example="us")] = "us",
+    category: Annotated[str | None, Field(description="News category", example="technology")] = None,
+    limit: Annotated[int, Field(gt=0, le=100, description="Number of articles to return")] = 5,
+) -> dict:
+    return await get_headlines(query=query, country=country, category=category, limit=limit)
 
 
 async def main() -> None:

--- a/mcp-news/news_service.py
+++ b/mcp-news/news_service.py
@@ -1,71 +1,59 @@
-"""Utility to fetch top news headlines using Google News RSS."""
+"""Fetch news headlines using the NewsAPI service."""
+
 from __future__ import annotations
 
 import os
-import time
-from typing import List, Tuple
+from typing import Any, Dict, Optional
 
 import httpx
-import xml.etree.ElementTree as ET
 
-# Cache structure: { (category, region, limit): (timestamp, summary_string) }
-_cache: dict[Tuple[str, str, int], Tuple[float, str]] = {}
-
-# Cache duration in seconds, configurable via env var NEWS_CACHE_TTL (default 600 sec)
-CACHE_TTL = int(os.getenv("NEWS_CACHE_TTL", "600"))
+API_KEY = os.getenv("NEWS_API")
 
 
-def _build_url(category: str | None, region: str | None) -> str:
-    """Build the Google News RSS URL for given category and region."""
-    base = "https://news.google.com/rss"
-    params = []
-    if region:
-        region = region.upper()
-        params.append(f"hl={region}")
-        params.append(f"gl={region}")
-        params.append(f"ceid={region}:{region}")
-    if category:
-        params.append(f"topic={category.upper()}")
-    return f"{base}?{'&'.join(params)}" if params else base
-
-
-def _parse_rss(xml_text: str, limit: int = 5) -> List[Tuple[str, str]]:
-    """Parse RSS XML and return list of (title, link)."""
-    root = ET.fromstring(xml_text)
-    items: List[Tuple[str, str]] = []
-    for item in root.findall("./channel/item")[:limit]:
-        title = item.findtext("title")
-        link = item.findtext("link")
-        if title and link:
-            items.append((title, link))
-    return items
+class NewsAPIError(Exception):
+    """Raised when the NewsAPI request fails."""
 
 
 async def get_headlines(
-    category: str | None = None,
-    region: str | None = None,
+    *,
+    query: Optional[str] = None,
+    country: Optional[str] = "us",
+    category: Optional[str] = None,
     limit: int = 5,
-) -> str:
-    """Return a chatbot-friendly summary of top news headlines."""
-    key = (category or "", region or "", limit)
-    now = time.time()
-    if key in _cache:
-        ts, summary = _cache[key]
-        if now - ts < CACHE_TTL:
-            return summary
+) -> Dict[str, Any]:
+    """Retrieve headlines from NewsAPI and return the JSON response.
 
-    url = _build_url(category, region)
+    Args:
+        query: Optional search term to filter articles.
+        country: Two-letter country code. Defaults to "us".
+        category: News category such as "technology" or "sports".
+        limit: Number of articles to return (max 100 per NewsAPI docs).
+
+    Returns:
+        Parsed JSON response from NewsAPI.
+
+    Raises:
+        NewsAPIError: If the request fails or the API key is missing.
+    """
+
+    if not API_KEY:
+        raise NewsAPIError("NEWS_API environment variable not set")
+
+    params = {"apiKey": API_KEY, "pageSize": limit}
+    if query:
+        params["q"] = query
+    if country:
+        params["country"] = country
+    if category:
+        params["category"] = category
+
+    url = "https://newsapi.org/v2/top-headlines"
     async with httpx.AsyncClient() as client:
-        resp = await client.get(url, timeout=10, follow_redirects=True)
-        resp.raise_for_status()
-        xml_text = resp.text
+        try:
+            resp = await client.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network errors
+            raise NewsAPIError(str(exc)) from exc
 
-    headlines = _parse_rss(xml_text, limit=limit)
-    if not headlines:
-        summary = "No headlines found."
-    else:
-        lines = [f"- {title} ({link})" for title, link in headlines]
-        summary = "\n".join(lines)
+    return resp.json()
 
-    _cache[key] = (now, summary)
-    return summary

--- a/tests/test_news_api.py
+++ b/tests/test_news_api.py
@@ -1,0 +1,38 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import httpx
+
+
+def test_get_headlines(monkeypatch):
+    monkeypatch.setenv("NEWS_API", "test-key")
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "news_service", root / "mcp-news" / "news_service.py"
+    )
+    news_service = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(news_service)
+
+    class MockResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    async def mock_get(self, url, params=None, timeout=10):
+        assert params["apiKey"] == "test-key"
+        return MockResp({"status": "ok", "articles": [{"title": "Test"}]})
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+
+    data = asyncio.run(news_service.get_headlines(limit=1))
+    assert data["status"] == "ok"
+    assert data["articles"][0]["title"] == "Test"
+


### PR DESCRIPTION
## Summary
- replace Google News RSS integration with NewsAPI service
- update docs and bearer-token server to use new JSON news headlines
- add tests for NewsAPI news service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897be837368832ea56bb5ac7a54c8f6